### PR TITLE
fix: update illuminate/support dependency to support Laravel 8 installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "license": "MIT",
     "require": {
-        "illuminate/support": "^5.0|^6.0|^7.0",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0",
         "php": ">=7.2.5"
     },
     "autoload": {


### PR DESCRIPTION
Verified this fixes install issue on Laravel 8 installs via fork reference.

Fixes #15 